### PR TITLE
Add count validations

### DIFF
--- a/src/Changeset/Errors.php
+++ b/src/Changeset/Errors.php
@@ -66,14 +66,18 @@ trait Errors
      *
      * @param string $field
      * @param string $action
+     * @param string $message
+     * @param mixed $constraint
      */
-    protected function addError($field, $action, $message = null)
+    protected function addError($field, $action, $message = null, $constraint = null)
     {
-        $message = $message ?: str_replace(
-            '{field}',
-            $this->humanize($field),
-            $this->messages[$action]
-        );
+        $message = is_null($message)
+            ? str_replace('{field}', $this->humanize($field), $this->messages[$action])
+            : $message;
+
+        $message = !is_null($constraint)
+            ? str_replace(['{count}', '{length}', '{number}'], $constraint, $message)
+            : $message;
 
         $this->errors[$field][] = $message;
     }

--- a/src/Changeset/Validations.php
+++ b/src/Changeset/Validations.php
@@ -45,18 +45,32 @@ trait Validations
 
     /**
      * Validates a change is an array of the given count.
+     *
+     * @param string $field Filed name to validate
+     * @param array $opts Validation options
+     *  'is'  - (int) the count must be exactly this value
+     *  'min' - (int) the count must be greater than or equal to this value
+     *  'max' - (int) the count must be less than or equal to this value
+     * @param string $message Error message
+     *
+     * @return $this
      */
     public function validateCount($field, $opts, $message = null)
     {
-        // TODO: Implement validateCount
+        if (isset($this->changes[$field]) && is_array($this->changes[$field])) {
+            $count = count($this->changes[$field]);
 
-        // $opts
-        // 'is' - the count must be exactly this value
-        // 'min' - the count must be greater than or equal to this value
-        // 'max' - the count must be less than or equal to this value
+            if (isset($opts['is']) && $count !== $opts['is']) {
+                $this->addError($field, 'count:is', $message, $opts['is']);
+            }
 
-        if (isset($this->changes[$field])) {
-            $this->addError($field, 'count', $message);
+            if (isset($opts['min']) && $count < $opts['min']) {
+                $this->addError($field, 'count:min', $message, $opts['min']);
+            }
+
+            if (isset($opts['max']) && $count > $opts['max']) {
+                $this->addError($field, 'count:max', $message, $opts['max']);
+            }
         }
 
         return $this;

--- a/tests/ChangesetValidationsTest.php
+++ b/tests/ChangesetValidationsTest.php
@@ -96,30 +96,29 @@ final class ChangesetValidationsTest extends TestCase
         $this->assertFalse($changeset->valid());
     }
 
-    // count TODO
+    // count
 
-    function test_validateCount_valid()
+    /**
+     * @dataProvider validCountProvider
+     */
+    public function test_validateCount_valid($attrs)
     {
-        // $attrs = $this->validAttrs;
-        //
-        // $changeset = new TestChangeset(TestSchema::class, $attrs);
-        // $this->assertTrue($changeset->valid());
+        $attrs = array_merge($this->validAttrs, $attrs);
 
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
+        $changeset = new TestChangeset(TestSchema::class, $attrs);
+        $this->assertTrue($changeset->valid());
     }
 
-    function test_validateCount_invalid()
+    /**
+     * @dataProvider invalidCountProvider
+     */
+    public function test_validateCount_invalid($attrs, $errors)
     {
-        // $attrs = $this->validAttrs;
-        //
-        // $changeset = new TestChangeset(TestSchema::class, $attrs);
-        // $this->assertFalse($changeset->valid());
+        $attrs = array_merge($this->validAttrs, $attrs);
 
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
+        $changeset = new TestChangeset(TestSchema::class, $attrs);
+        $this->assertFalse($changeset->valid());
+        $this->assertEquals($errors, $changeset->errors());
     }
 
     // exclusion
@@ -269,5 +268,36 @@ final class ChangesetValidationsTest extends TestCase
         $this->markTestIncomplete(
             'This test has not been implemented yet.'
         );
+    }
+
+    public function validCountProvider()
+    {
+        return [
+            'test valid min rule' => [['skill' => ['php']]],
+            'test valid max rule' => [['skill' => ['php', 'mysql', 'redis']]],
+            'test valid is rule'  => [['topic' => ['oop', 'design patterns']]],
+        ];
+    }
+
+    public function invalidCountProvider()
+    {
+        return [
+            'test invalid min rule' => [
+                ['skill' => []],
+                ['skill' => ['you need at least 1 Skills']],
+            ],
+            'test invalid max rule' => [
+                ['skill' => ['php', 'mysql', 'redis', 'erlang']],
+                ['skill' => ['you can have, at most 3, Skills']],
+            ],
+            'test invalid is and min rules'  => [
+                ['topic' => ['oop']],
+                ['topic' => ['you do not have 2 Topics', 'you need at least 2 Topics']],
+            ],
+            'test invalid is and max rules'  => [
+                ['topic' => ['oop', 'design patterns', 'functional programming']],
+                ['topic' => ['you do not have 2 Topics', 'you can have, at most 2, Topics']],
+            ],
+        ];
     }
 }

--- a/tests/Fixtures/TestChangeset.php
+++ b/tests/Fixtures/TestChangeset.php
@@ -13,15 +13,17 @@ class TestChangeset extends Changeset
      */
     public function change()
     {
-        $this
+        return $this
             ->cast([
                 'name', 'email', 'is_admin', 'age', 'money', 'password',
-                'password_confirmation', 'foo', 'bar', 'accept_tos',
-                'banana_count',
+                'password_confirmation', 'skill', 'topic', 'foo', 'bar',
+                'accept_tos', 'banana_count',
             ])
             ->validateAcceptance('accept_tos')
             ->validateChange('banana_count', $this->validateHasMoreThanTwo())
             ->validateConfirmation('password')
+            ->validateCount('skill', ['min' => 1, 'max' => 3])
+            ->validateCount('topic', ['is' => 2, 'min' => 2, 'max' => 2])
             ->validateExclusion('foo', ['bar', 'baz'])
             ->validateFormat('email', '/^.+@.+\..+$/')
             ->validateInclusion('bar', ['x', 'y'])

--- a/tests/Fixtures/TestSchema.php
+++ b/tests/Fixtures/TestSchema.php
@@ -23,6 +23,8 @@ class TestSchema extends Schema
             'password' => ['type' => 'string', 'virtual' => true],
             'password_confirmation' => ['type' => 'string', 'virtual' => true],
             'password_hash' => ['type' => 'string'],
+            'skill' => ['type' => 'array'],
+            'topic' => ['type' => 'array'],
             'foo' => ['type' => 'string'],
             'bar' => ['type' => 'string'],
             'banana_count' => ['type' => 'integer'],


### PR DESCRIPTION
#1 Add count validations:
- `Errors::addError` method modified to replace placeholders with constraint values in default error messages
- Count validation implemented
- Tests for count validation added (with `dataProvider`s)