### PR TITLE
Add length validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
     "email": "code@ryanwinchester.ca"
   }],
   "minimum-stability": "stable",
-  "require": {},
+  "require": {
+    "ext-mbstring": "*"
+  },
   "require-dev": {
     "phpunit/phpunit": "^6.3"
   },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,4 +18,9 @@
       <directory suffix="Test.php">./tests</directory>
     </testsuite>
   </testsuites>
+  <filter>
+    <whitelist>
+      <directory>./src</directory>
+    </whitelist>
+  </filter>
 </phpunit>

--- a/src/Changeset/Validations.php
+++ b/src/Changeset/Validations.php
@@ -59,18 +59,7 @@ trait Validations
     {
         if (isset($this->changes[$field]) && is_array($this->changes[$field])) {
             $count = count($this->changes[$field]);
-
-            if (isset($opts['is']) && $count !== $opts['is']) {
-                $this->addError($field, 'count:is', $message, $opts['is']);
-            }
-
-            if (isset($opts['min']) && $count < $opts['min']) {
-                $this->addError($field, 'count:min', $message, $opts['min']);
-            }
-
-            if (isset($opts['max']) && $count > $opts['max']) {
-                $this->addError($field, 'count:max', $message, $opts['max']);
-            }
+            $this->validateCountable($field, $count, 'count', $opts, $message);
         }
 
         return $this;
@@ -118,18 +107,21 @@ trait Validations
 
     /**
      * Validates a change is a string of the given length.
+     *
+     * @param string $field Filed name to validate
+     * @param array $opts Validation options
+     *  'is'  - (int) the length must be exactly this value
+     *  'min' - (int) the length must be greater than or equal to this value
+     *  'max' - (int) the length must be less than or equal to this value
+     * @param string $message Error message
+     *
+     * @return $this
      */
     public function validateLength($field, $opts, $message = null)
     {
-        // TODO: Implement validateLength
-
-        // $opts
-        // 'is' - the length must be exactly this value
-        // 'min' - the length must be greater than or equal to this value
-        // 'max' - the length must be less than or equal to this value
-
         if (isset($this->changes[$field]) && is_string($this->changes[$field])) {
-            $this->addError($field, 'length', $message);
+            $length = mb_strlen($this->changes[$field]);
+            $this->validateCountable($field, $length, 'length', $opts, $message);
         }
 
         return $this;
@@ -180,5 +172,36 @@ trait Validations
         // TODO: Implement validateSubset
 
         return $this;
+    }
+
+    /**
+     * Validates countable $field against $rules
+     *
+     * @param string $field Name of the field to validate
+     * @param int $count Value of the countable field
+     * @param string $action Action title
+     *  'count'  - validating count of an array
+     *  'length' - validating length of a string
+     * @param array $rules List of validation rules
+     *  'is'  - (int) the $count must be exactly this value
+     *  'min' - (int) the $count must be greater than or equal to this value
+     *  'max' - (int) the $count must be less than or equal to this value
+     * @param string $message Error message
+     *
+     * @return void
+     */
+    private function validateCountable($field, $count, $action, $rules, $message)
+    {
+        if (isset($rules['is']) && $count !== $rules['is']) {
+            $this->addError($field, $action . ':is', $message, $rules['is']);
+        }
+
+        if (isset($rules['min']) && $count < $rules['min']) {
+            $this->addError($field, $action . ':min', $message, $rules['min']);
+        }
+
+        if (isset($rules['max']) && $count > $rules['max']) {
+            $this->addError($field, $action . ':max', $message, $rules['max']);
+        }
     }
 }

--- a/tests/ChangesetValidationsTest.php
+++ b/tests/ChangesetValidationsTest.php
@@ -10,7 +10,7 @@ use Plasm\Tests\Fixtures\TestChangeset;
 use Plasm\Tests\Fixtures\TestSchema;
 
 /**
- * @covers \Plasm\ChangesetValidations
+ * @covers \Plasm\Changeset\Validations
  */
 final class ChangesetValidationsTest extends TestCase
 {

--- a/tests/ChangesetValidationsTest.php
+++ b/tests/ChangesetValidationsTest.php
@@ -181,30 +181,29 @@ final class ChangesetValidationsTest extends TestCase
         $this->assertFalse($changeset->valid());
     }
 
-    // length TODO
+    // length
 
-    function test_validateLength_valid()
+    /**
+     * @dataProvider validLengthProvider
+     */
+    function test_validateLength_valid($attrs)
     {
-        // $attrs = $this->validAttrs;
-        //
-        // $changeset = TestChangeset::using(TestSchema::class)->change($attrs);
-        // $this->assertTrue($changeset->valid());
+        $attrs = array_merge($this->validAttrs, $attrs);
 
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
+        $changeset = TestChangeset::using(TestSchema::class)->change($attrs);
+        $this->assertTrue($changeset->valid());
     }
 
-    function test_validateLength_invalid()
+    /**
+     * @dataProvider invalidLengthProvider
+     */
+    function test_validateLength_invalid($attrs, $errors)
     {
-        // $attrs = $this->validAttrs;
-        //
-        // $changeset = TestChangeset::using(TestSchema::class)->change($attrs);
-        // $this->assertFalse($changeset->valid());
+        $attrs = array_merge($this->validAttrs, $attrs);
 
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
+        $changeset = TestChangeset::using(TestSchema::class)->change($attrs);
+        $this->assertFalse($changeset->valid());
+        $this->assertEquals($errors, $changeset->errors());
     }
 
     // number TODO
@@ -273,30 +272,57 @@ final class ChangesetValidationsTest extends TestCase
     public function validCountProvider()
     {
         return [
-            'test valid min rule' => [['skill' => ['php']]],
-            'test valid max rule' => [['skill' => ['php', 'mysql', 'redis']]],
-            'test valid is rule'  => [['topic' => ['oop', 'design patterns']]],
+            'test valid count:min rule' => [['skill' => ['php']]],
+            'test valid count:max rule' => [['skill' => ['php', 'mysql', 'redis']]],
+            'test valid count:is rule'  => [['topic' => ['oop', 'design patterns']]],
         ];
     }
 
     public function invalidCountProvider()
     {
         return [
-            'test invalid min rule' => [
+            'test invalid count:min rule' => [
                 ['skill' => []],
                 ['skill' => ['you need at least 1 Skills']],
             ],
-            'test invalid max rule' => [
+            'test invalid count:max rule' => [
                 ['skill' => ['php', 'mysql', 'redis', 'erlang']],
                 ['skill' => ['you can have, at most 3, Skills']],
             ],
-            'test invalid is and min rules'  => [
+            'test invalid count:is and count:min rules'  => [
                 ['topic' => ['oop']],
                 ['topic' => ['you do not have 2 Topics', 'you need at least 2 Topics']],
             ],
-            'test invalid is and max rules'  => [
+            'test invalid count:is and count:max rules'  => [
                 ['topic' => ['oop', 'design patterns', 'functional programming']],
                 ['topic' => ['you do not have 2 Topics', 'you can have, at most 2, Topics']],
+            ],
+        ];
+    }
+
+    public function validLengthProvider()
+    {
+        return [
+            'test valid length:min rule' => [['name' => 'Ed']],
+            'test valid length:max rule' => [['name' => 'Pablo Diego José']],
+            'test valid length:is rule'  => [['password_hash' => md5('password')]],
+        ];
+    }
+
+    public function invalidLengthProvider()
+    {
+        return [
+            'test invalid length:min rule' => [
+                ['name' => 'Y'],
+                ['name' => ['you need at least 2 Names']],
+            ],
+            'test invalid length:max rule' => [
+                ['name' => 'Wolfeschlegelsteinhausenbergerdorff'],
+                ['name' => ['you can have, at most 16, Names']],
+            ],
+            'test invalid length:is rule'  => [
+                ['password_hash' => sha1('password')],
+                ['password_hash' => ['you do not have 32 Password hashs']],
             ],
         ];
     }

--- a/tests/Fixtures/TestChangeset.php
+++ b/tests/Fixtures/TestChangeset.php
@@ -16,12 +16,14 @@ class TestChangeset extends Changeset
         return $this
             ->cast($attrs, [
                 'name', 'email', 'is_admin', 'age', 'money', 'password',
-                'password_confirmation', 'skill', 'topic', 'foo', 'bar',
-                'accept_tos', 'banana_count',
+                'password_confirmation', 'password_hash', 'skill', 'topic',
+                'foo', 'bar', 'accept_tos', 'banana_count',
             ])
             ->validateAcceptance('accept_tos')
             ->validateChange('banana_count', $this->validateHasMoreThanTwo())
             ->validateConfirmation('password')
+            ->validateLength('name', ['min' => 2, 'max' => 16])
+            ->validateLength('password_hash', ['is' => 32])
             ->validateCount('skill', ['min' => 1, 'max' => 3])
             ->validateCount('topic', ['is' => 2, 'min' => 2, 'max' => 2])
             ->validateExclusion('foo', ['bar', 'baz'])


### PR DESCRIPTION
Part of #1: Add length validation

1. Length validation and unit tests added
2. Common logic for `count` and `length` validations extracted to a private method
3. `whitelist` section added to `phpunit.xml.dist` (required for code coverage)
4. PHP `mbstring` extension added as a platform requirement