### PR TITLE
Add number validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
   }],
   "minimum-stability": "stable",
   "require": {
+    "php": "^7.0",
     "ext-mbstring": "*"
   },
   "require-dev": {

--- a/src/Changeset/Validations.php
+++ b/src/Changeset/Validations.php
@@ -134,20 +134,51 @@ trait Validations
 
     /**
      * Validates the properties of a number.
+     *
+     * @param string $field Name of the field to validate
+     * @param array $opts Validation options
+     *  'less_than'
+     *  'greater_than'
+     *  'less_than_or_equal_to'
+     *  'greater_than_or_equal_to'
+     *  'equal_to'
+     * @param string $message Error message
+     *
+     * @return $this
      */
-    // public function validateNumber($field, $opts, $message = null)
-    // {
-    //     // TODO: Implement validateNumber
-    //
-    //     // $opts
-    //     // :less_than
-    //     // :greater_than
-    //     // :less_than_or_equal_to
-    //     // :greater_than_or_equal_to
-    //     // :equal_to
-    //
-    //     return $this;
-    // }
+    public function validateNumber($field, $opts, $message = null)
+    {
+        if (isset($this->changes[$field]) && is_numeric($this->changes[$field])) {
+            $number = $this->changes[$field];
+
+            $action = 'less_than';
+            if (isset($opts[$action]) && !($number < $opts[$action])) {
+                $this->addError($field, 'number:'.$action, $message, $opts[$action]);
+            }
+
+            $action = 'greater_than';
+            if (isset($opts[$action]) && !($number > $opts[$action])) {
+                $this->addError($field, 'number:'.$action, $message, $opts[$action]);
+            }
+
+            $action = 'less_than_or_equal_to';
+            if (isset($opts[$action]) && !($number <= $opts[$action])) {
+                $this->addError($field, 'number:'.$action, $message, $opts[$action]);
+            }
+
+            $action = 'greater_than_or_equal_to';
+            if (isset($opts[$action]) && !($number >= $opts[$action])) {
+                $this->addError($field, 'number:'.$action, $message, $opts[$action]);
+            }
+
+            $action = 'equal_to';
+            if (isset($opts[$action]) && ($number !== $opts[$action])) {
+                $this->addError($field, 'number:'.$action, $message, $opts[$action]);
+            }
+        }
+
+        return $this;
+    }
 
     /**
      * Validate that one or more fields are present in the changeset.

--- a/tests/ChangesetValidationsTest.php
+++ b/tests/ChangesetValidationsTest.php
@@ -254,32 +254,33 @@ final class ChangesetValidationsTest extends TestCase
         $this->assertEquals($errors, $changeset->errors());
     }
 
-    // number TODO
+    // number
 
-    /** @test */
-    function validateNumber_valid()
+    /**
+     * @test
+     * @dataProvider validNumberProvider
+     */
+    function validateNumber_valid($attrs)
     {
-        // $attrs = $this->validAttrs;
-        //
-        // $changeset = TestChangeset::using(TestSchema::class)->change($attrs);
-        // $this->assertTrue($changeset->valid());
+        $attrs = array_merge($this->validAttrs, $attrs);
 
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
+        $changeset = TestChangeset::using(TestSchema::class)->change($attrs);
+
+        $this->assertTrue($changeset->valid());
     }
 
-    /** @test */
-    function validateNumber_invalid()
+    /**
+     * @test
+     * @dataProvider invalidNumberProvider
+     */
+    function validateNumber_invalid($attrs, $errors)
     {
-        // $attrs = $this->validAttrs;
-        //
-        // $changeset = TestChangeset::using(TestSchema::class)->change($attrs);
-        // $this->assertFalse($changeset->valid());
+        $attrs = array_merge($this->validAttrs, $attrs);
 
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
+        $changeset = TestChangeset::using(TestSchema::class)->change($attrs);
+
+        $this->assertFalse($changeset->valid());
+        $this->assertEquals($errors, $changeset->errors());
     }
 
     // required
@@ -373,6 +374,43 @@ final class ChangesetValidationsTest extends TestCase
             'test invalid length:is rule'  => [
                 ['password_hash' => sha1('password')],
                 ['password_hash' => ['you do not have 32 Password hashs']],
+            ],
+        ];
+    }
+
+    function validNumberProvider()
+    {
+        return [
+            'test valid number:less_than rule' => [['money' => 999]],
+            'test valid number:greater_than rule' => [['money' => 1.01]],
+            'test valid number:less_than_or_equal_to rule' => [['age' => 60]],
+            'test valid number:greater_than_or_equal_to rule' => [['age' => 18]],
+            'test valid number:equal_to rule' => [['lucky' => 7]],
+        ];
+    }
+
+    function invalidNumberProvider()
+    {
+        return [
+            'test invalid number:less_than rule' => [
+                ['money' => 1000],
+                ['money' => ['Money should be less than 1000']],
+            ],
+            'test invalid number:greater_than rule' => [
+                ['money' => 1],
+                ['money' => ['Money should be greater than 1']],
+            ],
+            'test invalid number:less_than_or_equal_to rule' => [
+                ['age' => 61],
+                ['age' => ['Age should be less than or equal to 60']],
+            ],
+            'test invalid number:greater_than_or_equal_to rule' => [
+                ['age' => 17],
+                ['age' => ['Age should be greater than or equal to 18']],
+            ],
+            'test invalid number:equal_to rule' => [
+                ['lucky' => 13],
+                ['lucky' => ['Lucky should be equal to 7']],
             ],
         ];
     }

--- a/tests/Fixtures/TestChangeset.php
+++ b/tests/Fixtures/TestChangeset.php
@@ -19,7 +19,7 @@ class TestChangeset extends Changeset
             ->cast($attrs, [
                 'name', 'email', 'is_admin', 'age', 'money', 'password',
                 'password_confirmation', 'password_hash', 'skill', 'topic',
-                'foo', 'bar', 'accept_tos', 'banana_count', 'things',
+                'foo', 'bar', 'accept_tos', 'banana_count', 'things', 'lucky',
             ])
             ->validateAcceptance('accept_tos')
             ->validateChange('banana_count', $this->validateHasMoreThanTwo())
@@ -27,6 +27,9 @@ class TestChangeset extends Changeset
             ->validateConfirmation('password')
             ->validateLength('name', ['min' => 2, 'max' => 16])
             ->validateLength('password_hash', ['is' => 32])
+            ->validateNumber('age', ['greater_than_or_equal_to' => 18, 'less_than_or_equal_to' => 60])
+            ->validateNumber('money', ['greater_than' => 1, 'less_than' => 1000])
+            ->validateNumber('lucky', ['equal_to' => 7])
             ->validateCount('skill', ['min' => 1, 'max' => 3])
             ->validateCount('topic', ['is' => 2, 'min' => 2, 'max' => 2])
             ->validateExclusion('foo', ['bar', 'baz'])

--- a/tests/Fixtures/TestSchema.php
+++ b/tests/Fixtures/TestSchema.php
@@ -29,6 +29,7 @@ class TestSchema extends Schema
             'bar' => ['type' => 'string'],
             'banana_count' => ['type' => 'integer'],
             'things' => ['type' => 'array'],
+            'lucky' => ['type' => 'integer'],
         ];
     }
 }


### PR DESCRIPTION
Last bits of #1:
1. Number validation and unit tests added
2. PHP 7 version added as a platform requirement (since null coalescing operator is used)